### PR TITLE
Bump rubocop dependency versions and fix new offense

### DIFF
--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -11,10 +11,6 @@ AllCops:
   NewCops: enable
   TargetRubyVersion: 3.2
 
-# Put development dependencies in the gemspec so rubygems.org knows about them
-Gemspec/DevelopmentDependencies:
-  EnforcedStyle: gemspec
-
 # Make BeginEndAlignment behavior match EndAlignment
 Layout/BeginEndAlignment:
   EnforcedStyleAlignWith: begin

--- a/Gemfile
+++ b/Gemfile
@@ -8,9 +8,9 @@ group :development do
   gem "minitest", "~> 6.0"
   gem "rake", "~> 13.0"
   gem "rake-manifest", "~> 0.2.0"
-  gem "rubocop", "~> 1.79"
-  gem "rubocop-minitest", "~> 0.38.0"
+  gem "rubocop", "~> 1.85"
+  gem "rubocop-minitest", "~> 0.39.1"
   gem "rubocop-packaging", "~> 0.6.0"
-  gem "rubocop-performance", "~> 1.25"
+  gem "rubocop-performance", "~> 1.26"
   gem "simplecov", "~> 0.22.0"
 end

--- a/Gemfile
+++ b/Gemfile
@@ -3,3 +3,14 @@
 source "https://rubygems.org"
 
 gemspec
+
+group :development do
+  gem "minitest", "~> 6.0"
+  gem "rake", "~> 13.0"
+  gem "rake-manifest", "~> 0.2.0"
+  gem "rubocop", "~> 1.79"
+  gem "rubocop-minitest", "~> 0.38.0"
+  gem "rubocop-packaging", "~> 0.6.0"
+  gem "rubocop-performance", "~> 1.25"
+  gem "simplecov", "~> 0.22.0"
+end

--- a/gir_ffi-gst.gemspec
+++ b/gir_ffi-gst.gemspec
@@ -23,13 +23,4 @@ Gem::Specification.new do |spec|
   spec.require_paths = ["lib"]
 
   spec.add_dependency "gir_ffi", "~> 0.18.0"
-
-  spec.add_development_dependency "minitest", "~> 6.0"
-  spec.add_development_dependency "rake", "~> 13.0"
-  spec.add_development_dependency "rake-manifest", "~> 0.2.0"
-  spec.add_development_dependency "rubocop", "~> 1.79"
-  spec.add_development_dependency "rubocop-minitest", "~> 0.38.0"
-  spec.add_development_dependency "rubocop-packaging", "~> 0.6.0"
-  spec.add_development_dependency "rubocop-performance", "~> 1.25"
-  spec.add_development_dependency "simplecov", "~> 0.22.0"
 end

--- a/lib/gir_ffi-gst.rb
+++ b/lib/gir_ffi-gst.rb
@@ -6,6 +6,7 @@ GirFFI.setup :Gst
 GirFFI.setup :GstBase
 
 require "gir_ffi-gst/base"
+require "gir_ffi-gst/gst"
 require "gir_ffi-gst/bin"
 require "gir_ffi-gst/child_proxy"
 require "gir_ffi-gst/element"

--- a/lib/gir_ffi-gst/base.rb
+++ b/lib/gir_ffi-gst/base.rb
@@ -21,10 +21,3 @@ module GirFFIGst
     end
   end
 end
-
-# Overrides for Gst module functions
-module Gst
-  setup_method! "init"
-
-  include GirFFIGst::AutoArgv
-end

--- a/lib/gir_ffi-gst/gst.rb
+++ b/lib/gir_ffi-gst/gst.rb
@@ -1,0 +1,8 @@
+# frozen_string_literal: true
+
+# Overrides for Gst module functions
+module Gst
+  setup_method! "init"
+
+  include GirFFIGst::AutoArgv
+end


### PR DESCRIPTION
- **Move development dependencies to the Gemfile**
- **Bump minumum rubocop dependency versions**
- **Fix Style/OneClassPerFile offense**
